### PR TITLE
Add installation script / instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
+## Installation
+You have two options when it comes to installing and setting up UploadX. You can do it via the install.sh (in this repo), or you can do it manually. If you choose to do it manually...
 
+1.  Enable mod_rewrite - sudo a2enmod rewrite
+2.  Up your post_max_size and upload_max_filesize, both in php.ini. This prevents UploadX from returning http://domain.ext/index.php because the limit isn't high enough.
+3.  AllowOverride for the domain/folder - so htaccess works and data is private.
+4.  [Configure ShareX](https://github.com/PixelPips/UploadX/wiki/Client-Installation-and-Configuration).
+5.  You're done!
+
+## Features
 DONE:
 - json file that stores data that can be edited by the user via the script
 - web panel for administraton
@@ -25,4 +34,3 @@ TODO:
 
 - double check password when changing
 - style the shit out of it
-

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ DONE:
 - json file that stores data that can be edited by the user via the script
 - web panel for administraton
 - regenerate htaccess, links.json and data.json
+- yay! now, at night, you have the option to detect the **server**'s time and apply css accordingly!
 - password security: it will yell at you if your password is `password`
 - security
     - admin password preventing users from modifying settings

--- a/index.php
+++ b/index.php
@@ -216,7 +216,19 @@ else if (isset($_GET['id'])){
         $links[$link_id]['times_accessed']++; save_json();
         $link_uploader = $links[$link_id]['uploader'];
         $link_accessed = $links[$link_id]['times_accessed'];
-        
+
+    /*Detect if it's day or night (for the server, gotta use jQuery for client) and apply stylesheets accordingly. 
+      Defaults to false, as the user must provide their own stylesheets. 
+    */
+    $doSwitch = true;
+    if($doSwitch != false){
+        date_default_timezone_set(file_get_contents('/etc/timezone'));
+        $time = date("H"); // Set the time in 24 hour format
+        if (07 <= $time && $time < 19) // 7:00am to 7:00pm (Day)
+            {echo('<link rel="stylesheet" href="day.css" type="text/css">');}
+            else{ echo('<link rel="stylesheet" href="night.css" type="text/css">');}
+    }
+    //Now that that's that... here's the rest of the page!
         echo ('<center>');
         if ( strpos($link_filetype,'image') !== false ){
             //image

--- a/index.php
+++ b/index.php
@@ -220,7 +220,7 @@ else if (isset($_GET['id'])){
     /*Detect if it's day or night (for the server, gotta use jQuery for client) and apply stylesheets accordingly. 
       Defaults to false, as the user must provide their own stylesheets. 
     */
-    $doSwitch = true;
+    $doSwitch = false;
     if($doSwitch != false){
         date_default_timezone_set(file_get_contents('/etc/timezone'));
         $time = date("H"); // Set the time in 24 hour format

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#Written by gnosticJade - for Apache 2.4.7 / PHP 5.5.9 on Ubuntu 14.04. 
+#Should work on any version that keeps the files where it's hardcoded... and yes, I know this is sloppy, but it works.
+#If you want to just install it on your own, up post_max_size and upload_max_filesize, and enable mod_rewrite. Also AllowOverride for the domain so .htaccess functions properly.
+phpini="/etc/php5/apache2/php.ini"
+apacheconf="/etc/apache2/sites-enabled/"
+
+
+#Remove the lines that contain "post_max_size" and "upload_max_filesize", and replace it with the user's decision of maximum size in the php.ini file's default location.
+#This must be changed or UploadX will return domain.ext/index.php whenever a file is too large.
+echo "What's the largest file you'd like to let any user upload? eg. 30M for 30 megabytes, or 2G for two gigabytes."
+echo -n ">"
+read text
+sed -i "/upload_max_filesize/c\upload_max_filesize="$text"" "$phpini"
+sed -i "/post_max_size/c\post_max_size="$text"" "$phpini"
+
+#replace AllowOverride None (if applicable) with AllowOverride All
+echo ""
+echo "Which config file would you like to modify? Type the full file name."
+echo "Do NOT do this to a file that contains <Directory />"
+ls $apacheconf
+echo -n ">"
+read userInput
+echo "You chose: $userInput"
+sed -i '/AllowOverride None/c\AllowOverride All' /etc/apache2/sites-available/$userInput
+
+#enable mod_rewrite for apache
+a2enmod rewrite


### PR DESCRIPTION
20e4c31 - Adds installation instructions for Apache2/PHP5, or a [mostly] automated installer for Ubuntu 14.04, and makes the readme slightly prettier.
f901710 - The server now (optionally) checks against its own time. If it's between 7am and 7pm, it defaults to a day stylesheet. Any later than that, and it's a night stylesheet. The stylesheets are not included by default, and thus, it defaults to off.
47e33ae - fixing f901710's default.
